### PR TITLE
Drop declaration of hook, which is already generated

### DIFF
--- a/rescript-mode.el
+++ b/rescript-mode.el
@@ -72,11 +72,6 @@
 
     table))
 
-(defcustom rescript-mode-hook nil
-  "Hook called by `rescript-mode'."
-  :type 'hook
-  :group 'rescript)
-
 ;; in rescript-vscode grammar file, what are they?
 ;; import
 ;; library


### PR DESCRIPTION
define-derived-mode produces such a custom var if it is not already declared, so we just let it do that.

(in connection with https://github.com/melpa/melpa/pull/7545)