### PR TITLE
Add a proper value for `compilation-error-regexp-alist-alist'.

### DIFF
--- a/rescript-mode.el
+++ b/rescript-mode.el
@@ -175,7 +175,7 @@
   (defconst rescript--compilation-error-rx
     (rx-to-string
       '(seq
-         "We've found a bug for you!"
+         (or "We've found a bug for you!" "Syntax error!")
          (* (or space control))
          line-start
          (* space)
@@ -184,7 +184,7 @@
          (group (+ digit))
          ":"
          (group (+ digit))
-         (? "-" (group (+ digit)))
+         (? "-" (+ digit) (? ":" (+ digit)))
          line-end)))
 
 

--- a/rescript-mode.el
+++ b/rescript-mode.el
@@ -202,7 +202,7 @@
        (group (+ digit))
        ":"
        (group (+ digit))
-       (? "-" (group (+ digit)))
+       (? "-" (+ digit))
        line-end))))
 
 

--- a/rescript-mode.el
+++ b/rescript-mode.el
@@ -179,12 +179,12 @@
          (* (or space control))
          line-start
          (* space)
-         (group (seq (* any) ".res"))
-         ":"
-         (group (+ digit))
-         ":"
-         (group (+ digit))
-         (? "-" (+ digit) (? ":" (+ digit)))
+         (group (group (seq (* any) ".res"))
+           ":"
+           (group (+ digit))
+           ":"
+           (group (+ digit))
+           (? "-" (+ digit) (? ":" (+ digit))))
          line-end)))
 
 
@@ -197,12 +197,12 @@
        (* (or space control))
        line-start
        (* space)
-       (group (seq (* any) ".res"))
-       ":"
-       (group (+ digit))
-       ":"
-       (group (+ digit))
-       (? "-" (+ digit))
+       (group (group (seq (* any) ".res"))
+         ":"
+         (group (+ digit))
+         ":"
+         (group (+ digit))
+         (? "-" (+ digit)))
        line-end))))
 
 
@@ -211,11 +211,11 @@
 
 (add-to-list
   'compilation-error-regexp-alist-alist
-  (cons 'rescript-error (cons rescript--compilation-error-rx '(1 2 3 2 1))))
+  (cons 'rescript-error (cons rescript--compilation-error-rx '(2 3 4 2 1))))
 
 (add-to-list
   'compilation-error-regexp-alist-alist
-  (cons 'rescript-warning (cons rescript--compilation-warning-rx '(1 2 3 1 1))))
+  (cons 'rescript-warning (cons rescript--compilation-warning-rx '(2 3 4 1 1))))
 
 
 

--- a/rescript-mode.el
+++ b/rescript-mode.el
@@ -175,7 +175,15 @@
   (defconst rescript--compilation-error-rx
     (rx-to-string
       '(seq
-         (or "We've found a bug for you!" "Syntax error!")
+         (or
+           "We've found a bug for you!"
+           "Syntax error!"
+           (seq
+             "Warning number"
+             (* space)
+             (+ digit)
+             (* space)
+             "(configured as error)"))
          (* (or space control))
          line-start
          (* space)

--- a/rescript-mode.el
+++ b/rescript-mode.el
@@ -169,6 +169,56 @@
   ;; Fonts
   (setq-local font-lock-defaults '(rescript--font-lock-keywords)))
 
+
+;;; Compilation Error Regexs
+(eval-and-compile
+  (defconst rescript--compilation-error-rx
+    (rx-to-string
+      '(seq
+         "We've found a bug for you!"
+         (* (or space control))
+         line-start
+         (* space)
+         (group (seq (* any) ".res"))
+         ":"
+         (group (+ digit))
+         ":"
+         (group (+ digit))
+         (? "-" (group (+ digit)))
+         line-end)))
+
+
+  (defconst rescript--compilation-warning-rx
+    (rx-to-string
+    '(seq
+       "Warning number"
+       (+ space)
+       (+ digit)
+       (* (or space control))
+       line-start
+       (* space)
+       (group (seq (* any) ".res"))
+       ":"
+       (group (+ digit))
+       ":"
+       (group (+ digit))
+       (? "-" (group (+ digit)))
+       line-end))))
+
+
+(add-to-list 'compilation-error-regexp-alist 'rescript-error)
+(add-to-list 'compilation-error-regexp-alist 'rescript-warning)
+
+(add-to-list
+  'compilation-error-regexp-alist-alist
+  (cons 'rescript-error (cons rescript--compilation-error-rx '(1 2 3 2 1))))
+
+(add-to-list
+  'compilation-error-regexp-alist-alist
+  (cons 'rescript-warning (cons rescript--compilation-warning-rx '(1 2 3 1 1))))
+
+
+
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.resi?\\'" . rescript-mode))
 


### PR DESCRIPTION
When using [compilation](https://www.gnu.org/software/emacs/manual/html_node/emacs/Compilation.html) this is useful to properly recognize and navigate all errors.

I didn't include a default for the compilation command, though.  I usually use a Makefile with the following:

```
compile-rescript: $(RESCRIPT_FILES) yarn.lock
	[ -n "$(INSIDE_EMACS)" ] && (rescript build -with-deps | cat) || rescript build -with-deps
```

The pipe to `cat` being needed to remove the colors controls.
