### PR TITLE
Fix typo in Doom Emacs + eglot instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ Then in `config.el` add:
 ```elisp
 (after! eglot
   (add-to-list 'eglot-server-programs
-               '(rescript-mode . ("rescropt-language-server" "--stdio")))
+               '(rescript-mode . ("rescript-language-server" "--stdio")))
   )
 
 (add-hook 'rescript-mode-hook (lambda () (eglot-ensure)))


### PR DESCRIPTION
Thanks for this great package!
I just noticed a typo in installations instructions for the configuration I use (Doom + eglot).