### PR TITLE
 Improve rescript-ts-mode grammar installation and font-locking

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,41 @@ Restart spacemacs (`SPC q r`) and open a ReScript `.res` file and you should
 have all the features working.
 
 
+### Tree-sitter mode
+
+There is also an experimental tree-sitter based major mode,
+`rescript-ts-mode`, for Emacs 29.1 and newer.
+
+When `rescript-ts-mode` is enabled and the ReScript tree-sitter grammar is not
+installed yet, the mode can prompt to install it automatically. The grammar is
+installed using Emacs' built-in `treesit-install-language-grammar` support from
+this upstream repository:
+
+- `https://github.com/rescript/tree-sitter-rescript`
+
+You can also install it manually with:
+
+- `M-x rescript-ts-install-grammar`
+
+A minimal configuration looks like this:
+
+```elisp
+(use-package rescript-mode
+  :mode ("\\.resi?\\'" . rescript-ts-mode))
+```
+
+If you prefer to keep using `rescript-mode` by default, you can still enable
+`rescript-ts-mode` manually in individual buffers.
+
+Useful customization options:
+
+- `rescript-ts-prompt-to-install-grammar`
+- `rescript-ts-grammar-source-url`
+- `rescript-ts-grammar-install-directory`
+
+If the grammar fails to load, `M-x rescript-ts-diagnose-grammar` prints the
+relevant tree-sitter settings and grammar availability information.
+
 ### Formatting and indentation
 
 #### Formatting vs. Indentation
@@ -350,13 +385,10 @@ See the github issues, but notably:
 
 
  Emacs support
-* [Indentation](#indentation) is a terrible hack and should very likely be
-  replaced with
-  [tree-sitter-rescript](https://github.com/nkrkv/tree-sitter-rescript/) and
-  [elisp-tree-sitter](https://github.com/emacs-tree-sitter/elisp-tree-sitter)
-  and [tree-sitter-indent](https://github.com/emacsmirror/tree-sitter-indent) --
-  probably very easy?  Perhaps this will also improve font-lock etc!
-* Font lock and indentation are broken for things like `let \"try" = true`.
+* Classic `rescript-mode` indentation is a terrible hack.
+  `rescript-ts-mode` should behave better here, but it is still experimental.
+* Classic `rescript-mode` font lock and indentation are broken for things like
+  `let \"try" = true`.
 * Formatting with `lsp-format-buffer` is broken because it does not correctly
   handle the response from rescript-vscode because it uses a range like
   `"end":{"line":1.7976931348623157e+308,"character":1.7976931348623157e+308}`

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ installed yet, the mode can prompt to install it automatically. The grammar is
 installed using Emacs' built-in `treesit-install-language-grammar` support from
 this upstream repository:
 
-- `https://github.com/rescript/tree-sitter-rescript`
+- `https://github.com/rescript-lang/tree-sitter-rescript`
 
 You can also install it manually with:
 

--- a/rescript-mode.el
+++ b/rescript-mode.el
@@ -113,7 +113,7 @@ break string parsing."
 (defconst rescript--keywords
   '("and" "as" "assert" "async" "await"
     "constraint"
-    "else" "exception" "export" "external"
+    "dict{" "else" "exception" "export" "external"
     "false" "for"
     "if" "import" "in" "include"
     "lazy" "let" "list{"
@@ -131,7 +131,7 @@ break string parsing."
 
 (defconst rescript--special-types
   '("int" "float" "string" "char"
-    "bool" "unit" "list" "array" "exn"
+    "bool" "unit" "list" "dict" "array" "exn"
     "option" "ref"))
 
 (defconst rescript--camel-case

--- a/rescript-mode.el
+++ b/rescript-mode.el
@@ -132,7 +132,7 @@ break string parsing."
 (defconst rescript--special-types
   '("int" "float" "string" "char"
     "bool" "unit" "list" "dict" "array" "exn"
-    "option" "ref"))
+    "option" "ref" "promise" "result"))
 
 (defconst rescript--camel-case
   (rx symbol-start

--- a/rescript-ts-mode.el
+++ b/rescript-ts-mode.el
@@ -30,6 +30,29 @@
   :safe 'integerp
   :group 'rescript-ts)
 
+(defcustom rescript-ts-grammar-source-url
+  "https://github.com/rescript/tree-sitter-rescript"
+  "Git repository used by `rescript-ts-install-grammar'."
+  :type 'string
+  :group 'rescript-ts)
+
+(defcustom rescript-ts-grammar-install-directory nil
+  "Directory where `rescript-ts-install-grammar' installs the grammar.
+
+When nil, install to the standard tree-sitter directory under
+`user-emacs-directory'."
+  :type '(choice (const :tag "Default tree-sitter directory" nil)
+                 directory)
+  :group 'rescript-ts)
+
+(defcustom rescript-ts-prompt-to-install-grammar t
+  "Whether `rescript-ts-mode' should offer to install its grammar.
+
+When non-nil, calling `rescript-ts-mode' interactively prompts to install
+the ReScript tree-sitter grammar if it is missing."
+  :type 'boolean
+  :group 'rescript-ts)
+
 (defvar rescript-ts--indent-rules
   `((rescript
      ((parent-is "source_file") column-0 0)
@@ -75,7 +98,8 @@
    :language 'rescript
    '((string) @font-lock-string-face
      (template_string) @font-lock-string-face
-     (character) @font-lock-string-face)
+     (character) @font-lock-string-face
+     (regex) @font-lock-string-face)
 
    ;; Extension expressions like %re("/regex/") -- the extension_identifier
    ;; gets keyword face, and the string inside keeps its string face from above.
@@ -164,6 +188,53 @@
   "Feature list for font-locking in `rescript-ts-mode'.
 Each level adds more highlighting on top of the previous.")
 
+(defun rescript-ts-install-grammar (&optional out-dir)
+  "Install the ReScript tree-sitter grammar.
+
+If OUT-DIR is non-nil, install the grammar there.  Otherwise install it
+into `rescript-ts-grammar-install-directory' or Emacs' standard
+`tree-sitter' directory when that variable is nil."
+  (interactive
+   (list
+    (when current-prefix-arg
+      (read-directory-name "Install ReScript grammar to: "))))
+  (require 'treesit)
+  (setf (alist-get 'rescript treesit-language-source-alist)
+        rescript-ts-grammar-source-url)
+  (treesit-install-language-grammar
+   'rescript
+   (or out-dir rescript-ts-grammar-install-directory)))
+
+(defun rescript-ts-diagnose-grammar ()
+  "Show diagnostic information about the ReScript tree-sitter grammar."
+  (interactive)
+  (require 'treesit)
+  (message
+   "rescript available=%S ready=%S extra-load-path=%S override=%S source=%S"
+   (treesit-language-available-p 'rescript)
+   (treesit-ready-p 'rescript t)
+   treesit-extra-load-path
+   treesit-load-name-override-list
+   (alist-get 'rescript treesit-language-source-alist)))
+
+(defun rescript-ts--ensure-grammar ()
+  "Ensure the ReScript tree-sitter grammar is available."
+  (or (treesit-ready-p 'rescript)
+      (when (and rescript-ts-prompt-to-install-grammar
+                 (called-interactively-p 'interactive)
+                 (y-or-n-p
+                  (concat
+                   "ReScript tree-sitter grammar is missing. "
+                   "Install it now? ")))
+        (condition-case err
+            (progn
+              (rescript-ts-install-grammar)
+              (treesit-ready-p 'rescript))
+          (error
+           (user-error
+            "Failed to install ReScript tree-sitter grammar: %s"
+            (error-message-string err)))))))
+
 ;;;###autoload
 (define-derived-mode rescript-ts-mode prog-mode "ReScript"
   "Major mode for editing ReScript, powered by tree-sitter.
@@ -175,8 +246,11 @@ Each level adds more highlighting on top of the previous.")
                   (modify-syntax-entry ?* ". 23n" table)
                   (modify-syntax-entry ?\n "> b" table)
                   table)
-  (unless (treesit-ready-p 'rescript)
-    (error "Tree-sitter grammar for ReScript is not available"))
+  (unless (rescript-ts--ensure-grammar)
+    (error
+     (concat
+      "Tree-sitter grammar for ReScript is not available. "
+      "Run M-x rescript-ts-install-grammar to install it")))
 
   (treesit-parser-create 'rescript)
 
@@ -206,10 +280,9 @@ Each level adds more highlighting on top of the previous.")
 
   (treesit-major-mode-setup))
 
-;; NOTE: Not auto-enabled yet because the tree-sitter grammar does not
-;; support `dict' syntax (ReScript v11.1+), causing cascading parse
-;; errors.  Enable manually with M-x rescript-ts-mode, or uncomment
-;; the form below once the grammar is updated.
+;; NOTE: Not auto-enabled yet.
+;; Enable manually with M-x rescript-ts-mode, or uncomment
+;; the form below if you want to use it for all .res/.resi buffers.
 ;;
 ;; ;;;###autoload
 ;; (if (treesit-ready-p 'rescript t)

--- a/rescript-ts-mode.el
+++ b/rescript-ts-mode.el
@@ -31,9 +31,14 @@
   :group 'rescript-ts)
 
 (defcustom rescript-ts-grammar-source-url
-  "https://github.com/rescript/tree-sitter-rescript"
-  "Git repository used by `rescript-ts-install-grammar'."
-  :type 'string
+  "https://github.com/rescript-lang/tree-sitter-rescript"
+  "Source used by `rescript-ts-install-grammar'.
+
+This may be either a Git repository URL string or a full recipe list
+compatible with `treesit-language-source-alist'."
+  :type '(choice string
+                 (repeat :tag "Tree-sitter source recipe"
+                         (choice string sexp)))
   :group 'rescript-ts)
 
 (defcustom rescript-ts-grammar-install-directory nil
@@ -225,6 +230,20 @@ fontify within START and END."
   "Feature list for font-locking in `rescript-ts-mode'.
 Each level adds more highlighting on top of the previous.")
 
+(defun rescript-ts--grammar-source-recipe ()
+  "Return the tree-sitter source recipe for ReScript."
+  (if (listp rescript-ts-grammar-source-url)
+      rescript-ts-grammar-source-url
+    (list rescript-ts-grammar-source-url)))
+
+(defun rescript-ts--register-language-source ()
+  "Register the ReScript tree-sitter grammar source recipe."
+  (setf (alist-get 'rescript treesit-language-source-alist nil nil #'eq)
+        (rescript-ts--grammar-source-recipe)))
+
+(rescript-ts--register-language-source)
+
+;;;###autoload
 (defun rescript-ts-install-grammar (&optional out-dir)
   "Install the ReScript tree-sitter grammar.
 
@@ -236,12 +255,16 @@ into `rescript-ts-grammar-install-directory' or Emacs' standard
     (when current-prefix-arg
       (read-directory-name "Install ReScript grammar to: "))))
   (require 'treesit)
-  (setf (alist-get 'rescript treesit-language-source-alist)
-        rescript-ts-grammar-source-url)
-  (treesit-install-language-grammar
-   'rescript
-   (or out-dir rescript-ts-grammar-install-directory)))
+  (rescript-ts--register-language-source)
+  (let ((install-dir (or out-dir
+                         rescript-ts-grammar-install-directory
+                         (expand-file-name "tree-sitter" user-emacs-directory))))
+    (make-directory install-dir t)
+    (treesit-install-language-grammar
+     'rescript
+     install-dir)))
 
+;;;###autoload
 (defun rescript-ts-diagnose-grammar ()
   "Show diagnostic information about the ReScript tree-sitter grammar."
   (interactive)
@@ -252,7 +275,7 @@ into `rescript-ts-grammar-install-directory' or Emacs' standard
    (treesit-ready-p 'rescript t)
    treesit-extra-load-path
    treesit-load-name-override-list
-   (alist-get 'rescript treesit-language-source-alist)))
+   (alist-get 'rescript treesit-language-source-alist nil nil #'eq)))
 
 (defun rescript-ts--ensure-grammar ()
   "Ensure the ReScript tree-sitter grammar is available."

--- a/rescript-ts-mode.el
+++ b/rescript-ts-mode.el
@@ -24,6 +24,11 @@
   :prefix "rescript-ts-"
   :group 'languages)
 
+(defface rescript-ts-jsx-attribute-face
+  '((t :inherit font-lock-variable-name-face))
+  "Face for JSX attribute names in `rescript-ts-mode'."
+  :group 'rescript-ts)
+
 (defcustom rescript-ts-indent-offset 2
   "Number of spaces for each indentation step in `rescript-ts-mode'."
   :type 'integer
@@ -123,14 +128,20 @@ fontify within START and END."
    '((string) @font-lock-string-face
      (template_string) @font-lock-string-face
      (character) @font-lock-string-face
-     (regex) @font-lock-string-face)
+     (regex) @font-lock-regexp-face)
 
-   ;; Extension expressions like %re("/regex/") -- the extension_identifier
-   ;; gets keyword face, and the string inside keeps its string face from above.
+   ;; Extension expressions like %re("...")
    :feature 'extension
    :language 'rescript
+   :override t
    '((extension_expression
-      (extension_identifier) @font-lock-preprocessor-face))
+      "%" @font-lock-keyword-face
+      (extension_identifier) @font-lock-keyword-face)
+     ((extension_expression
+       (extension_identifier) @ext-id
+       (expression_statement
+        (string) @font-lock-regexp-face))
+      (:match "re" @ext-id)))
 
    ;; Builtin collection constructors and types
    :feature 'builtin
@@ -166,8 +177,7 @@ fontify within START and END."
    :language 'rescript
    '((true) @font-lock-constant-face
      (false) @font-lock-constant-face
-     (unit) @font-lock-constant-face
-     (polyvar) @font-lock-constant-face)
+     (unit) @font-lock-constant-face)
 
    ;; Types
    :feature 'type
@@ -190,14 +200,35 @@ fontify within START and END."
    :feature 'parameter
    :language 'rescript
    '((parameter (value_identifier) @font-lock-variable-name-face)
+     (labeled_parameter (value_identifier) @font-lock-variable-name-face)
+     (function parameter: (value_identifier) @font-lock-variable-name-face)
      (parameter
-      (labeled_parameter
-       (value_identifier) @font-lock-variable-name-face)))
+      (tuple_pattern
+       (tuple_item_pattern
+        (value_identifier) @font-lock-variable-name-face)))
+     (parameter
+      (array_pattern
+       (value_identifier) @font-lock-variable-name-face))
+     (parameter
+      (record_pattern
+       (value_identifier) @font-lock-variable-name-face))
+     (parameter
+      (list_pattern
+       (value_identifier) @font-lock-variable-name-face))
+     (parameter
+      (list_pattern
+       (spread_pattern
+        (value_identifier) @font-lock-variable-name-face))))
 
    ;; Variant constructors
    :feature 'constructor
    :language 'rescript
-   '((variant_identifier) @font-lock-type-face)
+   :override t
+   '((variant_identifier) @font-lock-type-face
+     (polyvar_identifier) @font-lock-type-face
+     (polyvar) @font-lock-type-face
+     (polyvar_string) @font-lock-type-face
+     (polyvar_type_pattern "#" @font-lock-type-face))
 
    ;; Decorators like @module, @scope, @send, etc.
    :feature 'decorator
@@ -208,8 +239,25 @@ fontify within START and END."
    :feature 'property
    :language 'rescript
    :override t
-   '((record_type_field (property_identifier) @font-lock-variable-name-face)
-     (record_field (property_identifier) @font-lock-variable-name-face))
+   '((dict_entry (string) @font-lock-property-name-face (_))
+     (dict_pattern_entry (string) @font-lock-property-name-face (_))
+     (record_type_field (property_identifier) @font-lock-property-name-face)
+     (record_field (property_identifier) @font-lock-property-name-face)
+     (object (field (property_identifier) @font-lock-property-name-face (_)))
+     (object_type (field (property_identifier) @font-lock-property-name-face (_))))
+
+   ;; JSX
+   :feature 'jsx
+   :language 'rescript
+   :override t
+   '((jsx_identifier) @font-lock-type-face
+     (jsx_attribute (property_identifier) @rescript-ts-jsx-attribute-face)
+     (jsx_element
+      open_tag: (jsx_opening_element ["<" ">"] @font-lock-bracket-face))
+     (jsx_element
+      close_tag: (jsx_closing_element ["<" "/" ">"] @font-lock-bracket-face))
+     (jsx_self_closing_element ["/" ">" "<"] @font-lock-bracket-face)
+     (jsx_fragment [">" "<" "/"] @font-lock-bracket-face))
 
    ;; Operators
    :feature 'operator
@@ -226,7 +274,7 @@ fontify within START and END."
 (defvar rescript-ts--font-lock-feature-list
   '((comment string)
     (keyword type builtin constant number)
-    (function parameter constructor decorator extension property)
+    (function parameter constructor decorator extension property jsx)
     (operator escape-sequence))
   "Feature list for font-locking in `rescript-ts-mode'.
 Each level adds more highlighting on top of the previous.")

--- a/rescript-ts-mode.el
+++ b/rescript-ts-mode.el
@@ -136,7 +136,8 @@ fontify within START and END."
    :feature 'builtin
    :language 'rescript
    :override t
-   '((type_identifier) @rescript-ts--fontify-builtin-collection
+   '((unit_type) @font-lock-builtin-face
+     (type_identifier) @rescript-ts--fontify-builtin-collection
      (dict) @rescript-ts--fontify-builtin-collection
      (dict_pattern) @rescript-ts--fontify-builtin-collection
      (list) @rescript-ts--fontify-builtin-collection

--- a/rescript-ts-mode.el
+++ b/rescript-ts-mode.el
@@ -180,6 +180,14 @@ fontify within START and END."
       function: (value_identifier_path
                  (value_identifier) @font-lock-function-call-face)))
 
+   ;; Parameters
+   :feature 'parameter
+   :language 'rescript
+   '((parameter (value_identifier) @font-lock-variable-name-face)
+     (parameter
+      (labeled_parameter
+       (value_identifier) @font-lock-variable-name-face)))
+
    ;; Variant constructors
    :feature 'constructor
    :language 'rescript
@@ -212,7 +220,7 @@ fontify within START and END."
 (defvar rescript-ts--font-lock-feature-list
   '((comment string)
     (keyword type builtin constant number)
-    (function constructor decorator extension property)
+    (function parameter constructor decorator extension property)
     (operator escape-sequence))
   "Feature list for font-locking in `rescript-ts-mode'.
 Each level adds more highlighting on top of the previous.")

--- a/rescript-ts-mode.el
+++ b/rescript-ts-mode.el
@@ -86,6 +86,25 @@ the ReScript tree-sitter grammar if it is missing."
      (no-node parent-bol 0)))
   "Tree-sitter indentation rules for ReScript.")
 
+(defun rescript-ts--fontify-builtin-collection (node override start end &rest _)
+  "Fontify collection builtins represented by NODE.
+
+Highlight `list' and `dict' consistently in both type positions and
+constructor forms like `list{}' and `dict{}'.  Respect OVERRIDE and only
+fontify within START and END."
+  (let* ((node-start (treesit-node-start node))
+         (node-end (treesit-node-end node))
+         (text (buffer-substring-no-properties node-start node-end))
+         (limit (cond
+                 ((string-prefix-p "list" text) (+ node-start 4))
+                 ((string-prefix-p "dict" text) (+ node-start 4)))))
+    (when limit
+      (treesit-fontify-with-override
+       (max node-start start)
+       (min limit end)
+       'font-lock-builtin-face
+       override))))
+
 (defvar rescript-ts--font-lock-settings
   (treesit-font-lock-rules
    ;; Comments
@@ -107,6 +126,16 @@ the ReScript tree-sitter grammar if it is missing."
    :language 'rescript
    '((extension_expression
       (extension_identifier) @font-lock-preprocessor-face))
+
+   ;; Builtin collection constructors and types
+   :feature 'builtin
+   :language 'rescript
+   :override t
+   '((type_identifier) @rescript-ts--fontify-builtin-collection
+     (dict) @rescript-ts--fontify-builtin-collection
+     (dict_pattern) @rescript-ts--fontify-builtin-collection
+     (list) @rescript-ts--fontify-builtin-collection
+     (list_pattern) @rescript-ts--fontify-builtin-collection)
 
    ;; Numbers
    :feature 'number
@@ -182,7 +211,7 @@ the ReScript tree-sitter grammar if it is missing."
 
 (defvar rescript-ts--font-lock-feature-list
   '((comment string)
-    (keyword type constant number)
+    (keyword type builtin constant number)
     (function constructor decorator extension property)
     (operator escape-sequence))
   "Feature list for font-locking in `rescript-ts-mode'.


### PR DESCRIPTION
This PR improves the experimental tree-sitter-based `rescript-ts-mode` in a few practical areas, and also tightens a couple of classic/tree-sitter font-lock gaps.

### What’s included

- add built-in support for installing the ReScript tree-sitter grammar
- prompt interactively to install the grammar when `rescript-ts-mode` is enabled and the grammar is missing
- add `rescript-ts-install-grammar` and `rescript-ts-diagnose-grammar` helper commands
- register the grammar source in a more robust way and fix the upstream grammar URL
- ensure the install directory exists before invoking `treesit-install-language-grammar`
- improve font-lock in `rescript-ts-mode` for:
  - labeled parameters
  - `list` / `dict` builtins in type positions, literals, and patterns
  - `unit` in type positions via `unit_type`
  - regex nodes as strings
- align classic `rescript-mode` font-lock so:
  - `dict` is highlighted like `list`
  - `promise` and `result` are highlighted as builtin types

### Customization

- `rescript-ts-prompt-to-install-grammar`
- `rescript-ts-grammar-source-url`
- `rescript-ts-grammar-install-directory`

### Motivation

Getting `rescript-ts-mode` running currently requires some manual tree-sitter setup, and when the grammar is missing the failure mode is not very friendly. This change makes the mode easier to try out by providing an installation flow directly from Emacs, along with a diagnosis command for troubleshooting.

On the highlighting side, this makes `rescript-ts-mode` feel more complete and also keeps classic `rescript-mode` and `rescript-ts-mode` closer in common builtin/type cases.

### Notes

- `rescript-ts-mode` remains experimental and is still not auto-enabled by default.
- This PR fixes the grammar source to use `https://github.com/rescript-lang/tree-sitter-rescript`.
