### PR TITLE
Fix ReScript tree-sitter comment highlights

### DIFF
--- a/rescript-ts-mode.el
+++ b/rescript-ts-mode.el
@@ -120,7 +120,7 @@ fontify within START and END."
    ;; Comments
    :feature 'comment
    :language 'rescript
-   '((comment) @font-lock-comment-face)
+   '([(line_comment) (block_comment)] @font-lock-comment-face)
 
    ;; Strings
    :feature 'string


### PR DESCRIPTION
The ReScript grammar now exposes line_comment and block_comment nodes instead of a generic comment node.

See tree-sitter-rescript commit
https://github.com/rescript-lang/tree-sitter-rescript/commit/6254b2a0e33c882ca67bcb4947efb209e4d10f9a